### PR TITLE
Pass options to child <select> elements if `this` is not a select el.

### DIFF
--- a/bootstrap-duallistbox/jquery.bootstrap-duallistbox.js
+++ b/bootstrap-duallistbox/jquery.bootstrap-duallistbox.js
@@ -37,7 +37,7 @@
             if (!$this.is("select"))
             {
                 return $this.find("select").each(function(index, item) {
-                    $(item).bootstrapDualListbox();
+                    $(item).bootstrapDualListbox(options);
                 });
             }
 


### PR DESCRIPTION
Options are lost if you don't call bootstrapDualListbox on a <select> el.
