### PR TITLE
fix: clear filter after disable filter

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -124,9 +124,8 @@
     if (dualListbox.settings.showFilterInputs) {
       filter(dualListbox, 1);
       filter(dualListbox, 2);
-
-      refreshInfo(dualListbox);
     }
+    refreshInfo(dualListbox);
   }
 
   function filter(dualListbox, selectIndex) {
@@ -575,14 +574,17 @@
       return this.element;
     },
     setShowFilterInputs: function(value, refresh) {
-      this.settings.showFilterInputs = value;
       if (!value) {
+        this.setNonSelectedFilter('');
+        this.setSelectedFilter('');
+        refreshSelects(this);
         this.elements.filterInput1.hide();
         this.elements.filterInput2.hide();
       } else {
         this.elements.filterInput1.show();
         this.elements.filterInput2.show();
       }
+      this.settings.showFilterInputs = value;
       if (refresh) {
         refreshSelects(this);
       }


### PR DESCRIPTION
When the filter is disabled, the filters must be cleared before hiding the `input`s.
