### PR TITLE
fix(filter): propagate `filtered#` changes to generated selects too

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
                     filterPlaceHolder: 'FILTER',
                     filterSelected: '2',
                     filterNonSelected: '1',
-                    moveOnSelect: false,
+                    moveOnSelect: true,
                     preserveSelectionOnMove: 'all',
                     helperSelectNamePostfix: '_myhelper',
                     selectedListLabel: 'Selected elements',

--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -153,6 +153,7 @@
         dualListbox.elements['select'+selectIndex].append($item.clone(true).prop('selected', $item.data('_selected')));
       }
       dualListbox.element.find('option').eq($item.data('original-index')).data('filtered'+selectIndex, isFiltered);
+      dualListbox.elements['select' + selectIndex].find('option').eq($item.data('original-index')).data('filtered'+selectIndex, isFiltered);
     });
 
     refreshInfo(dualListbox);


### PR DESCRIPTION
Clearing a filter did not propagate the filter changes back to the generated selects, so when trying to move an option (that didn't previously match the filter) right after clearing the filter, caused nothing at all.

This was due to the `move`/`remove`/`moveAll`/`removeAll` functions relying on the `filtered#` data attribute on the generated selects, not the original one.

With the following configuration:
- `moveOnSelect: true`
- `nonSelectedFilter: '1'`
- options: `['1','2','3']`

when I try to clear the filter and then move the option `2` or `3`, they are not moved on the first click, but only on the second one.
I think this is caused by the `filtered1`/`filtered2` data attribute which is not reset on the dual listbox generated selects.