### PR TITLE
Hides .info when infoText is set to false

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -612,6 +612,13 @@
     },
     setInfoText: function(value, refresh) {
       this.settings.infoText = value;
+      if (value) {
+        this.elements.info1.show();
+        this.elements.info2.show();
+      } else {
+        this.elements.info1.hide();
+        this.elements.info2.hide();
+      }
       if (refresh) {
         refreshSelects(this);
       }


### PR DESCRIPTION
It avoids the margin that this element introduces between the 'select labels' and the 'select widgets' when the info text must not be shown

_Screenshot of the widget before the change_

![without_patch](https://cloud.githubusercontent.com/assets/932124/5142247/7befc1e6-7180-11e4-93fe-e8142679a0c5.png)

_Screenshot of the widget after the change_

![after_patch](https://cloud.githubusercontent.com/assets/932124/5142258/aa427e76-7180-11e4-85d4-6335fea2317d.png)
