### PR TITLE
Improve the performance by avoiding repeated DOM queries in loop

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -137,10 +137,11 @@
 
     dualListbox.elements['select'+selectIndex].empty().scrollTop(0);
     var regex = new RegExp($.trim(dualListbox.elements['filterInput'+selectIndex].val()), 'gi'),
+      allOptions = dualListbox.element.find('option'),
       options = dualListbox.element;
 
     if (selectIndex === 1) {
-      options = options.find('option').not(':selected');
+      options = allOptions.not(':selected');
     } else  {
       options = options.find('option:selected');
     }
@@ -152,16 +153,17 @@
         isFiltered = false;
         dualListbox.elements['select'+selectIndex].append($item.clone(true).prop('selected', $item.data('_selected')));
       }
-      dualListbox.element.find('option').eq($item.data('original-index')).data('filtered'+selectIndex, isFiltered);
+      allOptions.eq($item.data('original-index')).data('filtered'+selectIndex, isFiltered);
     });
 
     refreshInfo(dualListbox);
   }
 
   function saveSelections(dualListbox, selectIndex) {
+    var options = dualListbox.element.find('option');
     dualListbox.elements['select'+selectIndex].find('option').each(function(index, item) {
       var $item = $(item);
-      dualListbox.element.find('option').eq($item.data('original-index')).data('_selected', $item.prop('selected'));
+      options.eq($item.data('original-index')).data('_selected', $item.prop('selected'));
     });
   }
 


### PR DESCRIPTION
The options of the element are the same for each iteration of the loop over selected/unselected options, so querying the DOM only once is enough, and makes things faster (I tested this with a select box containing 8000 elements).