### PR TITLE
Fix filtered move-on-select.

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -133,7 +133,9 @@
       return;
     }
 
-    saveSelections(dualListbox, selectIndex);
+    if (!dualListbox.settings.moveOnSelect) {
+      saveSelections(dualListbox, selectIndex);
+    }
 
     dualListbox.elements['select'+selectIndex].empty().scrollTop(0);
     var regex = new RegExp($.trim(dualListbox.elements['filterInput'+selectIndex].val()), 'gi'),


### PR DESCRIPTION
Move-on-select + filtering was broken as previously the code selected
one of the filtered options. Now, as clicking on the selected option
does not trigger a change event it was thus impossible to deselect that
option.