### PR TITLE
Include CSS in bower.json main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,10 @@
     }
 	],
 	"description": "A responsive dual listbox widget optimized for Twitter Bootstrap. It works on all modern browsers and on touch devices.",
-	"main": "src/jquery.bootstrap-duallistbox.js",
+	"main": [
+	  "src/jquery.bootstrap-duallistbox.js",
+	  "src/bootstrap-duallistbox.css"
+  ],
   "dependencies": {
     "jquery": "~2.0.3",
     "bootstrap": ">=2.3.2"


### PR DESCRIPTION
The Bower JSON needs to include CSS files as well, beyond scripts. See [spec](https://github.com/bower/bower.json-spec#main).