### PR TITLE
Fix: SortByInputOrder remove would unorder list

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -251,6 +251,9 @@
     refreshSelects(dualListbox);
     triggerChangeEvent(dualListbox);
     sortOptions(dualListbox.elements.select1);
+    if(dualListbox.settings.sortByInputOrder){
+        sortOptionsByInputOrder(dualListbox.elements.select2);
+    }
   }
 
   function moveAll(dualListbox) {


### PR DESCRIPTION
When using SortByInputOrder, moving fields over works correctly, but when you remove a field, it would be reordered the way you would expect when not using SortByInputOrder.