### PR TITLE
Filter: if moveOnSelect is active do not copy over selected status.

### DIFF
--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -168,7 +168,9 @@
       return;
     }
 
-    saveSelections(dualListbox, selectIndex);
+    if (!dualListbox.settings.moveOnSelect) {
+      saveSelections(dualListbox, selectIndex);
+    }
 
     dualListbox.elements['select'+selectIndex].empty().scrollTop(0);
     var regex,


### PR DESCRIPTION
When filtering the selects and then selecting one of the items the current code automatically saves the selection. This break move-on-select: the item is already selected and cannot be deselected again (the latter maybe depending on the browser).